### PR TITLE
Add feature for processing keyword arguments to be passed for cubes configuration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changes in 0.11.2 (in development)
 
+- Added a feature to allow a user to pass processing keyword arguments 
+  (`processing_kwargs`) for cubes configuration. (#114)
+  
 ## Changes in 0.11.1
 
 - Renamed main branch from `master` to `main`.

--- a/xcube_sh/chunkstore.py
+++ b/xcube_sh/chunkstore.py
@@ -741,6 +741,7 @@ class SentinelHubChunkStore(RemoteStore):
             mosaicking_order=self.cube_config.mosaicking_order,
             collection_id=self.cube_config.collection_id,
             band_units=self.cube_config.band_units,
+            processing_kwargs=self.cube_config.processing_kwargs,
         )
 
         response = self._sentinel_hub.get_data(

--- a/xcube_sh/config.py
+++ b/xcube_sh/config.py
@@ -75,15 +75,15 @@ class CubeConfig:
         than separate arrays.
     :param exception_type: The type of exception to be raised on error
     :param processing_kwargs: Processing Keywords Arguments to be passed to Sentinel Hub
-    such as for S1GRD -> {
+        such as for S1GRD -> ``{
                     "orthorectify": "false",
                     "backCoeff": "GAMMA0_ELLIPSOID",
                     "speckleFilter": {
                         "type": "LEE",
                         "windowSizeX": 5,
                         "windowSizeY": 5
-                    }
-    defaults to None
+                    }``.
+        Defaults to ``None``.
     """
 
     def __init__(

--- a/xcube_sh/config.py
+++ b/xcube_sh/config.py
@@ -74,6 +74,16 @@ class CubeConfig:
     :param four_d: If variables should appear as forth dimension rather
         than separate arrays.
     :param exception_type: The type of exception to be raised on error
+    :param processing_kwargs: Processing Keywords Arguments to be passed to Sentinel Hub
+    such as for S1GRD -> {
+                    "orthorectify": "false",
+                    "backCoeff": "GAMMA0_ELLIPSOID",
+                    "speckleFilter": {
+                        "type": "LEE",
+                        "windowSizeX": 5,
+                        "windowSizeY": 5
+                    }
+    defaults to None
     """
 
     def __init__(
@@ -98,6 +108,7 @@ class CubeConfig:
         collection_id: str = None,
         four_d: bool = False,
         exception_type=ValueError,
+        processing_kwargs: dict = None,
     ):
         crs = crs or DEFAULT_CRS
         if crs in CRS_URI_TO_ID:
@@ -260,6 +271,7 @@ class CubeConfig:
         self._size = width, height
         self._tile_size = tile_width, tile_height
         self._num_tiles = width // tile_width, height // tile_height
+        self._processing_kwargs = processing_kwargs
 
     @classmethod
     def from_dict(
@@ -428,3 +440,7 @@ class CubeConfig:
             num_tiles = _safe_int_div(size, tile_size)
             size = num_tiles * tile_size
         return size
+
+    @property
+    def processing_kwargs(self) -> dict:
+        return self._processing_kwargs

--- a/xcube_sh/sentinelhub.py
+++ b/xcube_sh/sentinelhub.py
@@ -505,7 +505,7 @@ class SentinelHub:
         processing = {"upsampling": upsampling, "downsampling": downsampling}
 
         if processing_kwargs:
-            processing |= processing_kwargs if processing_kwargs else {}
+            processing |= processing_kwargs
 
         data_element = {
             "type": dataset_name if collection_id is None else collection_id,

--- a/xcube_sh/sentinelhub.py
+++ b/xcube_sh/sentinelhub.py
@@ -489,6 +489,7 @@ class SentinelHub:
         collection_id: str = None,
         band_units: Union[str, Sequence[str]] = None,
         band_sample_types: Union[str, Sequence[str]] = None,
+        processing_kwargs: dict = None,
     ) -> Dict:
         if bbox is None:
             bbox = [-180.0, -90.0, 180.0, 90.0]
@@ -501,9 +502,14 @@ class SentinelHub:
         if isinstance(band_sample_types, str):
             band_sample_types = [band_sample_types] * len(band_names)
 
+        processing = {"upsampling": upsampling, "downsampling": downsampling}
+
+        if processing_kwargs:
+            processing |= processing_kwargs if processing_kwargs else {}
+
         data_element = {
             "type": dataset_name if collection_id is None else collection_id,
-            "processing": {"upsampling": upsampling, "downsampling": downsampling},
+            "processing": processing,
         }
 
         if any([time_range, mosaicking_order, collection_id]):


### PR DESCRIPTION
This PR allows an user to pass processing arguments for cubes configuration.

Resolves issue: https://github.com/xcube-dev/xcube-sh/issues/114 

Example:
```
processing_kwargs = {
    "orthorectify": "true",
    "backCoeff": "SIGMA0_ELLIPSOID",
    "speckleFilter": {
        "type": "LEE",
        "windowSizeX": 3,
        "windowSizeY": 3
        }
}

cube_config = CubeConfig(dataset_name='S1GRD',
                         band_names=['VH'],
                         tile_size=[512, 512],
                         crs="http://www.opengis.net/def/crs/EPSG/0/4326",
                         spatial_res = spatial_res,
                         bbox=bbox,
                         time_range=['2019-05-14', '2019-07-31'],
                         time_period='2D',
                         processing_kwargs=processing_kwargs)
```






