### PR TITLE
Fixed request of byocs

### DIFF
--- a/xcube_sh/sentinelhub.py
+++ b/xcube_sh/sentinelhub.py
@@ -523,7 +523,7 @@ class SentinelHub:
             if mosaicking_order and time_range:
                 data_element["dataFilter"].update(mosaickingOrder=mosaicking_order)
             if collection_id:
-                data_element["dataFilter"].update(collectionId=collection_id)
+                data_element["type"] = collection_id
 
         input_element = {
             "bounds": {


### PR DESCRIPTION
Due to changes to the Sentinel Hub Process API, querying the xcube does not work for BYOC collections. 

Changing the single line to also just pass the byoc-id into `type` makes the requests work again. See the API reference: https://docs.sentinel-hub.com/api/latest/reference/#tag/process/operation/process